### PR TITLE
Update to support ChirpStack Gateway Bridge v3.5 config (#26)

### DIFF
--- a/configuration/chirpstack-gateway-bridge/chirpstack-gateway-bridge.toml
+++ b/configuration/chirpstack-gateway-bridge/chirpstack-gateway-bridge.toml
@@ -2,6 +2,6 @@
 # configuration example and documentation.
 
 [integration.mqtt.auth.generic]
-server="tcp://mosquitto:1883"
+servers=["tcp://mosquitto:1883"]
 username=""
 password=""

--- a/docker-compose-env.yml
+++ b/docker-compose-env.yml
@@ -27,7 +27,7 @@ services:
     ports:
       - 1700:1700/udp
     environment:
-      - INTEGRATION.MQTT.AUTH.GENERIC.SERVER=tcp://mosquitto:1883
+      - INTEGRATION__MQTT__AUTH__GENERIC__SERVERS=tcp://mosquitto:1883
 
   chirpstack-geolocation-server:
     image: chirpstack/chirpstack-geolocation-server:3


### PR DESCRIPTION
v3.5 replaces the dot (.) separated env. variables by double underscores (__). Dots do work within Docker, but are not valid for env. variable names. It also implements supports for defining a list of MQTT servers instead of a single server.